### PR TITLE
fix: exit MCP server on client disconnect

### DIFF
--- a/src/imap/client.test.ts
+++ b/src/imap/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
 import { ImapClient, createClientFromEnv, classifyImapError } from "./client.js";
 import type { ImapConfig } from "./types.js";
 
@@ -178,9 +179,7 @@ describe("ImapClient", () => {
 
   it("logs and clears cached client on error event", async () => {
     const client = new ImapClient(testConfig);
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true);
+    const stderrSpy = vi.spyOn(fs, "writeSync").mockImplementation(() => 0);
 
     await client.connect();
 
@@ -190,6 +189,7 @@ describe("ImapClient", () => {
     mockFlow._emit("error", err);
 
     expect(stderrSpy).toHaveBeenCalledWith(
+      process.stderr.fd,
       expect.stringMatching(/IMAP connection error:/)
     );
 

--- a/src/imap/client.ts
+++ b/src/imap/client.ts
@@ -1,5 +1,6 @@
 import { ImapFlow } from "imapflow";
 import type { ImapConfig } from "./types.js";
+import { safeStderrWrite } from "../stderr.js";
 
 /**
  * Classify an IMAP/network error into a clear, actionable message.
@@ -145,7 +146,7 @@ export class ImapClient {
     // so reconnect behavior is immediate even if ordering changes.
     flow.on("error", (error) => {
       const err = classifyImapError(error, this.config);
-      process.stderr.write(`IMAP connection error: ${err.message}\n`);
+      safeStderrWrite(`IMAP connection error: ${err.message}\n`);
       this.client = null;
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,8 @@ import "dotenv/config";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createClientFromEnv } from "./imap/index.js";
 import { createServer } from "./server.js";
+import { safeStderrWrite } from "./stderr.js";
 
-// Keep the process alive on unexpected errors — log to stderr so the
-// MCP client (Claude Desktop) can surface the message in its logs.
 function formatError(label: string, err: unknown): string {
   const lines = [`[imap-mini-mcp] ${label}`];
   if (err instanceof Error) {
@@ -27,35 +26,65 @@ function formatError(label: string, err: unknown): string {
   return lines.join("\n") + "\n";
 }
 
-process.on("uncaughtException", (err) => {
-  process.stderr.write(formatError("UNCAUGHT EXCEPTION", err));
-});
-process.on("unhandledRejection", (reason) => {
-  process.stderr.write(formatError("UNHANDLED REJECTION", reason));
-});
+function logFatalError(label: string, err: unknown): void {
+  safeStderrWrite(formatError(label, err));
+}
 
 async function main() {
-  // Create IMAP client from environment variables
   const imapClient = createClientFromEnv();
-
-  // Create the MCP server with all tools registered
   const server = createServer(imapClient);
-
-  // Connect via stdio transport
   const transport = new StdioServerTransport();
-  await server.connect(transport);
 
-  // Graceful shutdown
-  const shutdown = async () => {
-    await imapClient.disconnect();
-    process.exit(0);
+  let isShuttingDown = false;
+
+  const shutdown = async (exitCode: number = 0) => {
+    if (isShuttingDown) {
+      return;
+    }
+    isShuttingDown = true;
+
+    try {
+      await imapClient.disconnect();
+    } catch (error) {
+      logFatalError("SHUTDOWN ERROR", error);
+      exitCode = 1;
+    }
+
+    process.exit(exitCode);
   };
 
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  const handleFatalError = (label: string, err: unknown) => {
+    logFatalError(label, err);
+    void shutdown(1);
+  };
+
+  process.on("uncaughtException", (err) => {
+    handleFatalError("UNCAUGHT EXCEPTION", err);
+  });
+  process.on("unhandledRejection", (reason) => {
+    handleFatalError("UNHANDLED REJECTION", reason);
+  });
+
+  process.stdin.on("end", () => {
+    void shutdown(0);
+  });
+  process.stdin.on("close", () => {
+    void shutdown(0);
+  });
+  process.on("SIGHUP", () => {
+    void shutdown(0);
+  });
+  process.on("SIGINT", () => {
+    void shutdown(0);
+  });
+  process.on("SIGTERM", () => {
+    void shutdown(0);
+  });
+
+  await server.connect(transport);
 }
 
 main().catch((error) => {
-  console.error("Fatal error:", error);
+  logFatalError("FATAL ERROR", error);
   process.exit(1);
 });

--- a/src/stderr.ts
+++ b/src/stderr.ts
@@ -1,0 +1,16 @@
+import fs from "node:fs";
+
+/**
+ * Write diagnostics to stderr without throwing if the stdio pipe is gone.
+ *
+ * MCP stdio servers can outlive their parent process if the client crashes or
+ * disconnects unexpectedly. In that state, normal stderr writes may throw
+ * EPIPE and trigger another uncaught exception.
+ */
+export function safeStderrWrite(message: string): void {
+  try {
+    fs.writeSync(process.stderr.fd, message);
+  } catch {
+    // Ignore write failures during shutdown or after the parent disconnects.
+  }
+}


### PR DESCRIPTION
## Summary
- exit the MCP server when stdin closes or the parent process disconnects
- treat uncaught exceptions and unhandled rejections as fatal instead of leaving the process alive
- make stderr logging resilient to broken pipes so disconnected stdio sessions cannot spin in an error loop

## Validation
- npm test
- npm run lint
- npm run build

## Background
This fixes a real-world failure mode where the stdio MCP subprocess could outlive its client and keep burning CPU after disconnect.